### PR TITLE
updated backend to retry a failed HTTP resource request from google s…

### DIFF
--- a/assets/js/Sheets_package/gsheetsapi.js
+++ b/assets/js/Sheets_package/gsheetsapi.js
@@ -1,3 +1,11 @@
+function syncDelay(milliseconds){
+  var start = new Date().getTime();
+  var end=0;
+  while( (end-start) < milliseconds){
+      end = new Date().getTime();
+  }
+ }
+ 
 
 
 const gsheetsAPI = function (sheetId, sheetNumber = 1) {
@@ -5,7 +13,9 @@ const gsheetsAPI = function (sheetId, sheetNumber = 1) {
   let fetchFunc;
 
   try {
+
     fetchFunc = window.fetch;
+    
   } catch (err) {
     fetchFunc = nodefetch;
   }
@@ -15,6 +25,7 @@ const gsheetsAPI = function (sheetId, sheetNumber = 1) {
 
     return fetchFunc(sheetsUrl)
       .then(response => {
+        //console.log(response)
         if (!response.ok) {
           console.log('there is an error in the gsheets response');
           throw new Error('Error fetching GSheet');

--- a/assets/js/Sheets_package/gsheetsprocessor.js
+++ b/assets/js/Sheets_package/gsheetsprocessor.js
@@ -123,7 +123,7 @@ function processGSheetResults(
   return filterResults(processedResults, filter, filterOptions);
 }
 
-const gsheetProcessor = function (options, callback, onError) {
+function gsheetProcessor (options, callback, onError) {
   return GSheetsapi(
     options.sheetId,
     options.sheetNumber ? options.sheetNumber : 1
@@ -144,4 +144,15 @@ const gsheetProcessor = function (options, callback, onError) {
     .catch(err => onError(err.message));
 };
 
-export default gsheetProcessor;
+const gsheetProcessor_persitant=async function(options, callback, onError)
+{
+  let sheet_data=null;
+  while(sheet_data==null)
+  { 
+     sheet_data=  await gsheetProcessor(options,callback,onError);
+  }
+  return sheet_data;
+}
+
+
+export default gsheetProcessor_persitant;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-import GSheetProcessor from './Sheets_package/gsheetsprocessor.js';
+import gsheetProcessor_persitant from './Sheets_package/gsheetsprocessor.js';
 
 function cvtTabledataToDictionary(table_data,key_name)
 {
@@ -19,20 +19,22 @@ In order to use a new sheet in the google drive.
 3: The sheetid is the one from the sheet url not the publish link you are given if steps 1-2
 4: The cvtTabledataToDictionary is their to convert the table data to conform to the 
 */
-let hostSheet_data= await GSheetProcessor(
-  {
-    sheetId: '1J9F4Ojckm9Wm10GVjdjEFFkZL-49Yzxo2S7S-AfP5Eo',
-    sheetNumber: 1,
-    returnAllResults: true
-  },
-  results=>{
-    return results;
-  },
-  error => {console.log('error from sheets API', error); }
+
+let hostSheet_data= await gsheetProcessor_persitant(
+{
+  sheetId: '1J9F4Ojckm9Wm10GVjdjEFFkZL-49Yzxo2S7S-AfP5Eo',
+  sheetNumber: 1,
+  returnAllResults: true
+},
+results=>{
+  return results;
+},
+error => {console.log('Retrying sheet access', error); }
 );
+
 hostSheet_data=cvtTabledataToDictionary(hostSheet_data,"GroupName");
 
-let eventSheet_data= await GSheetProcessor(
+let eventSheet_data= await gsheetProcessor_persitant(
   {
     sheetId: '1J9F4Ojckm9Wm10GVjdjEFFkZL-49Yzxo2S7S-AfP5Eo',
     sheetNumber: 2,
@@ -41,20 +43,20 @@ let eventSheet_data= await GSheetProcessor(
   results=>{
     return results;
   },
-  error => {console.log('error from sheets API', error); }
+  error => {console.log('Retrying sheet access', error); }
 );
 eventSheet_data=cvtTabledataToDictionary(eventSheet_data,"GroupName");
 //console.log( eventSheet_data);
 
 
-let organizersSheet_data= await GSheetProcessor(
+let organizersSheet_data= await gsheetProcessor_persitant(
   {
     sheetId: '1cb2mUDwpOJCu2hwmGt__Ka7u8bDrh6K2eOc2blI248s',
     sheetNumber: 1,
     returnAllResults: true
   },
   results=>{return results;},
-  error => {console.log('error from sheets API', error); }
+  error => {console.log('Retrying sheet access', error); }
 );
 organizersSheet_data=cvtTabledataToDictionary(organizersSheet_data,"Name");
 
@@ -557,7 +559,7 @@ function populateEvents(events,hosts){
     $eventSection.append($row_div);
     $row_div = $("<div />").addClass("row");
     count++;
-    console.log(count)
+    //console.log(count)
   }
 
 


### PR DESCRIPTION
There was an issue with the site where google sheets would sometime turn down our http request. I've altered that backend to keep retrying. The main.js file now just calls a different custom api function which was made, so it's used the same as before minus the stochastic issue. 

Kwanda is working on loading icons so in the event of multiple retries the user is presented with visual indication that the data is on it's way.

The push will fix the "empty" section error that could occur, while Kwanda is still  working on making the "waiting" look better.