### PR TITLE
Add loading gifs for when website reads from the Gsheet

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1305,3 +1305,19 @@ section.team {
   border-radius: 10px 10px 10px 10px;
   color: #8a8a8a;
 }
+.loader {
+  border: 12px solid #8a8a8a7c; 
+  border-top: 12px solid #ffffff; 
+  border-radius: 50%;
+  width: 100px;
+  height: 100px;
+  animation: spin 1s linear infinite;
+  margin:auto;
+  top: 70px;
+  position:relative;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -500,7 +500,10 @@ function shuffle(array) {
 function populateEvents(events,hosts){
   // if(Object.keys(events).length==0) 
   //   return;
-  
+  var $eventSection = $(".events .container");
+
+  var loader = $(".events .container .loader");
+  loader.hide();
   
   var count = 0;
   for(var event_key of Object.keys(events)){
@@ -509,7 +512,6 @@ function populateEvents(events,hosts){
     if(events[event_key].EventTitle == undefined){
       continue;
     }
-    var $eventSection = $(".events .container");
     
     var $slot = $("<div />").addClass("col-md-2 col-xs-3")
     .append(
@@ -571,8 +573,11 @@ function populateHosts(hosts) {
   var $row_div = $("<div />").addClass("row");
   var count = 1;
 
+  var $hostSection = $(".hosts .container");
+  var loader = $(".hosts .container .loader");
+  loader.hide();
+
   for(var host_key of Object.keys(hosts)) {
-    var $hostSection = $(".hosts .container");
 
     var $slot = $("<div />").addClass("col-md-3 col-xs-6")
     .append(

--- a/index.html
+++ b/index.html
@@ -331,6 +331,8 @@
   <section id="ts-schedule" class="section events">
     <div class="container">
       <h2 class="section-title">Upcoming Roadshow Events</h2>
+      <!-- CSS loader --> 
+      <div class="loader"></div> 
 
     </div>
   </section>
@@ -338,7 +340,9 @@
 
   <section id="hosts" class="section hosts">
     <div class="container">
-      <h2 class="section-title">Roadshow Hosts</h2>
+      <h2 class="section-title">Roadshow Hosts</h2>      
+      <!-- CSS loader --> 
+      <div class="loader"></div> 
 
     </div>
   </section>


### PR DESCRIPTION
Added CSS loading gifs so that users know to expect content under the host sections (website takes a bit of time to read from the Gsheet). 

Issues: 
- Gdrive hosted images don't load sometimes.